### PR TITLE
Fix typescript issue

### DIFF
--- a/es6-promise-pool.d.ts
+++ b/es6-promise-pool.d.ts
@@ -2,7 +2,7 @@ interface Options<A> {
   promise?: PromiseLike<A>
 }
 
-declare class PromisePool<A> extends EventTarget {
+declare class PromisePool<A> {
   constructor(
     source: () => PromiseLike<A>|void,
     concurrency: number,


### PR DESCRIPTION
When importing

```javascript
import PromisePool from 'es6-promise-pool';
```

I get the following error:

```
node_modules/es6-promise-pool/es6-promise-pool.d.ts(5,38): error TS2304: Cannot find name 'EventTarget'.
```

So I edited the typings file and removed the `extends`.

```
$ node --version
v8.10.0
$ npm --version
5.7.1
```

Package version: `"es6-promise-pool": "^2.5.0"`